### PR TITLE
Find closest A to fix nesting bug

### DIFF
--- a/example/ui.js
+++ b/example/ui.js
@@ -28,21 +28,21 @@ module.exports = function (fastn, state) {
   const homePage = () => fastn('section',
     fastn('h1', 'Home Page'),
     fastn('p',
-      'This is an example of using the router'
+      'This is an example of using the router.'
     )
   );
 
   const secondPage = () => fastn('section',
     fastn('h1', 'Second Page'),
     fastn('p',
-      'This is the second page'
+      'This is the second page.'
     )
   );
 
   const thirdPage = () => fastn('section',
     fastn('h1', 'Third Page'),
     fastn('p',
-      'This is the third page, it will navigate home after 3 seconds'
+      'This is the third page, it will navigate home after 3 seconds.'
     )
       .on('render', function () {
         setTimeout(() => {
@@ -56,7 +56,7 @@ module.exports = function (fastn, state) {
   const nestedPage = () => fastn('section',
     fastn('h1', 'Nested Link Page'),
     fastn('p',
-      'This is the nested link page. It\'s link content is nested in a span'
+      'This is the nested link page. It\'s link content is nested in a span.'
     )
   );
 

--- a/example/ui.js
+++ b/example/ui.js
@@ -17,6 +17,10 @@ module.exports = function (fastn, state) {
     fastn('li', { class: isActive('/third') },
       fastn('a', { href: '/third' }, 'Third')),
 
+    fastn('li', { class: isActive('/nested') },
+      fastn('a', { href: '/nested' },
+        fastn('span', 'Nested'))),
+
     fastn('li', { class: isActive('/missing') },
       fastn('a', { href: '/missing' }, 'Missing'))
   );
@@ -49,6 +53,13 @@ module.exports = function (fastn, state) {
       })
   );
 
+  const nestedPage = () => fastn('section',
+    fastn('h1', 'Nested Link Page'),
+    fastn('p',
+      'This is the nested link page. It\'s link content is nested in a span'
+    )
+  );
+
   const notFoundPage = () => fastn('section', 'Not Found');
 
   const pagesUi = () => fastn('templater', {
@@ -66,6 +77,9 @@ module.exports = function (fastn, state) {
 
         case '/third':
           return thirdPage();
+
+        case '/nested':
+          return nestedPage();
 
         default:
           return notFoundPage();

--- a/pushStateAnchors.js
+++ b/pushStateAnchors.js
@@ -10,7 +10,7 @@ function pushStateAnchors (event) {
   
   if (href && !href.match(/.*?\/\//)) {
     event.preventDefault();
-    alert('yes')
+    setPath(href);
   }
 }
 

--- a/pushStateAnchors.js
+++ b/pushStateAnchors.js
@@ -3,11 +3,11 @@ const setPath = require('./setPath');
 function pushStateAnchors (event) {
   const closestAnchor = event.target.closest('a');
   if (!closestAnchor) {
-    return
+    return;
   }
 
   const href = closestAnchor.getAttribute('href');
-  
+
   if (href && !href.match(/.*?\/\//)) {
     event.preventDefault();
     setPath(href);

--- a/pushStateAnchors.js
+++ b/pushStateAnchors.js
@@ -1,11 +1,16 @@
 const setPath = require('./setPath');
 
 function pushStateAnchors (event) {
-  const href = event.target.getAttribute('href');
+  const closestAnchor = event.target.closest('a');
+  if (!closestAnchor) {
+    return
+  }
 
+  const href = closestAnchor.getAttribute('href');
+  
   if (href && !href.match(/.*?\/\//)) {
     event.preventDefault();
-    setPath(href);
+    alert('yes')
   }
 }
 


### PR DESCRIPTION
This fixes https://github.com/markwylde/spath/issues/4 where nested elements inside an anchor would not trigger setPath.

```html
<a href="/nested">
  <span>Nested Text</span>
</a>
```